### PR TITLE
chore: adding github.mcp version endpoint

### DIFF
--- a/v1.2.3/v0/servers/com.github.mcp/versions/0.11.0/index.html
+++ b/v1.2.3/v0/servers/com.github.mcp/versions/0.11.0/index.html
@@ -1,0 +1,45 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "com.github.mcp",
+		"description": "GitHub's official MCP Server",
+		"repository": {
+			"id": "36087466-7e8c-4b0b-bb5a-e8e0529d51f1",
+			"url": "https://github.com/github/github-mcp-server",
+			"source": "github"
+		},
+		"version": "0.11.0",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://api.githubcopilot.com/mcp",
+				"headers": [
+					{
+						"name": "Authorization",
+						"value": "Bearer {github_mcp_pat}",
+						"description": "Header used for authentication",
+						"isRequired": true,
+						"isSecret": false,
+						"format": "string",
+						"variables": {
+							"github_mcp_pat": {
+								"description": "GitHub Personal Access Token https://github.com/settings/personal-access-tokens/new",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2025-08-01T00:00:00Z",
+			"updatedAt": "2025-08-01T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}


### PR DESCRIPTION
The following endpoint `https://kortex-hub.github.io/mcp-registry-online/v1.2.3/v0/servers/com.github.mcp/0.11.0` goes 404 