### PR TITLE
feat: add atlassian, fetch, grafana, linux, notion, playwright, and podman MCP servers

### DIFF
--- a/v1.2.3/v0/servers/ai.openkaiden.registry/atlassian/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/atlassian/index.html
@@ -1,0 +1,44 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/atlassian",
+		"description": "Remote MCP Server connecting Jira and Confluence with LLMs and IDEs",
+		"repository": {
+			"url": "https://github.com/atlassian/atlassian-mcp-server",
+			"source": "github"
+		},
+		"version": "1.0.0",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://mcp.atlassian.com/v1/mcp",
+				"headers": [
+					{
+						"name": "Authorization",
+						"value": "Bearer {atlassian_token}",
+						"description": "Header used for authentication",
+						"isRequired": true,
+						"isSecret": false,
+						"format": "string",
+						"variables": {
+							"atlassian_token": {
+								"description": "Atlassian API token or OAuth access token https://support.atlassian.com/atlassian-rovo-mcp-server/docs/authentication-and-authorization/",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/atlassian/versions/1.0.0/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/atlassian/versions/1.0.0/index.html
@@ -1,0 +1,44 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/atlassian",
+		"description": "Remote MCP Server connecting Jira and Confluence with LLMs and IDEs",
+		"repository": {
+			"url": "https://github.com/atlassian/atlassian-mcp-server",
+			"source": "github"
+		},
+		"version": "1.0.0",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://mcp.atlassian.com/v1/mcp",
+				"headers": [
+					{
+						"name": "Authorization",
+						"value": "Bearer {atlassian_token}",
+						"description": "Header used for authentication",
+						"isRequired": true,
+						"isSecret": false,
+						"format": "string",
+						"variables": {
+							"atlassian_token": {
+								"description": "Atlassian API token or OAuth access token https://support.atlassian.com/atlassian-rovo-mcp-server/docs/authentication-and-authorization/",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/fetch/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/fetch/index.html
@@ -1,0 +1,32 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/fetch",
+		"description": "MCP server providing tools to fetch and convert web content for LLMs",
+		"repository": {
+			"url": "https://github.com/modelcontextprotocol/servers",
+			"source": "github",
+			"subfolder": "src/fetch"
+		},
+		"version": "2025.4.7",
+		"packages": [
+			{
+				"registryType": "pypi",
+				"identifier": "mcp-server-fetch",
+				"version": "2025.4.7",
+				"runtimeHint": "uvx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/fetch/versions/2025.4.7/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/fetch/versions/2025.4.7/index.html
@@ -1,0 +1,32 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/fetch",
+		"description": "MCP server providing tools to fetch and convert web content for LLMs",
+		"repository": {
+			"url": "https://github.com/modelcontextprotocol/servers",
+			"source": "github",
+			"subfolder": "src/fetch"
+		},
+		"version": "2025.4.7",
+		"packages": [
+			{
+				"registryType": "pypi",
+				"identifier": "mcp-server-fetch",
+				"version": "2025.4.7",
+				"runtimeHint": "uvx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/grafana/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/grafana/index.html
@@ -1,0 +1,47 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/grafana",
+		"description": "MCP server for Grafana observability platform",
+		"repository": {
+			"url": "https://github.com/grafana/mcp-grafana",
+			"source": "github"
+		},
+		"version": "0.13.0",
+		"packages": [
+			{
+				"registryType": "pypi",
+				"identifier": "mcp-grafana",
+				"version": "0.13.0",
+				"runtimeHint": "uvx",
+				"transport": {
+					"type": "stdio"
+				},
+				"environmentVariables": [
+					{
+						"name": "GRAFANA_URL",
+						"description": "Grafana instance URL (e.g. http://localhost:3000)",
+						"isRequired": true,
+						"isSecret": false,
+						"format": "string"
+					},
+					{
+						"name": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+						"description": "Grafana service account token for authentication",
+						"isRequired": true,
+						"isSecret": true,
+						"format": "string"
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/grafana/versions/0.13.0/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/grafana/versions/0.13.0/index.html
@@ -1,0 +1,47 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/grafana",
+		"description": "MCP server for Grafana observability platform",
+		"repository": {
+			"url": "https://github.com/grafana/mcp-grafana",
+			"source": "github"
+		},
+		"version": "0.13.0",
+		"packages": [
+			{
+				"registryType": "pypi",
+				"identifier": "mcp-grafana",
+				"version": "0.13.0",
+				"runtimeHint": "uvx",
+				"transport": {
+					"type": "stdio"
+				},
+				"environmentVariables": [
+					{
+						"name": "GRAFANA_URL",
+						"description": "Grafana instance URL (e.g. http://localhost:3000)",
+						"isRequired": true,
+						"isSecret": false,
+						"format": "string"
+					},
+					{
+						"name": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+						"description": "Grafana service account token for authentication",
+						"isRequired": true,
+						"isSecret": true,
+						"format": "string"
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/linux/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/linux/index.html
@@ -1,0 +1,31 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/linux",
+		"description": "Tools to allow LLM clients to interact with Linux systems remotely",
+		"repository": {
+			"url": "https://github.com/rhel-lightspeed/linux-mcp-server",
+			"source": "github"
+		},
+		"version": "1.4.1",
+		"packages": [
+			{
+				"registryType": "pypi",
+				"identifier": "linux-mcp-server",
+				"version": "1.4.1",
+				"runtimeHint": "uvx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/linux/versions/1.4.1/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/linux/versions/1.4.1/index.html
@@ -1,0 +1,31 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/linux",
+		"description": "Tools to allow LLM clients to interact with Linux systems remotely",
+		"repository": {
+			"url": "https://github.com/rhel-lightspeed/linux-mcp-server",
+			"source": "github"
+		},
+		"version": "1.4.1",
+		"packages": [
+			{
+				"registryType": "pypi",
+				"identifier": "linux-mcp-server",
+				"version": "1.4.1",
+				"runtimeHint": "uvx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/notion/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/notion/index.html
@@ -1,0 +1,40 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/notion",
+		"description": "Official Notion MCP Server",
+		"repository": {
+			"url": "https://github.com/makenotion/notion-mcp-server",
+			"source": "github"
+		},
+		"version": "2.2.1",
+		"packages": [
+			{
+				"registryType": "npm",
+				"identifier": "@notionhq/notion-mcp-server",
+				"version": "2.2.1",
+				"runtimeHint": "npx",
+				"transport": {
+					"type": "stdio"
+				},
+				"environmentVariables": [
+					{
+						"name": "NOTION_API_KEY",
+						"description": "Notion integration token from https://www.notion.so/my-integrations",
+						"isRequired": true,
+						"isSecret": true,
+						"format": "string"
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/notion/versions/2.2.1/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/notion/versions/2.2.1/index.html
@@ -1,0 +1,40 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/notion",
+		"description": "Official Notion MCP Server",
+		"repository": {
+			"url": "https://github.com/makenotion/notion-mcp-server",
+			"source": "github"
+		},
+		"version": "2.2.1",
+		"packages": [
+			{
+				"registryType": "npm",
+				"identifier": "@notionhq/notion-mcp-server",
+				"version": "2.2.1",
+				"runtimeHint": "npx",
+				"transport": {
+					"type": "stdio"
+				},
+				"environmentVariables": [
+					{
+						"name": "NOTION_API_KEY",
+						"description": "Notion integration token from https://www.notion.so/my-integrations",
+						"isRequired": true,
+						"isSecret": true,
+						"format": "string"
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/playwright/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/playwright/index.html
@@ -1,0 +1,31 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/playwright",
+		"description": "Playwright MCP server for browser automation using accessibility snapshots",
+		"repository": {
+			"url": "https://github.com/microsoft/playwright-mcp",
+			"source": "github"
+		},
+		"version": "0.0.73",
+		"packages": [
+			{
+				"registryType": "npm",
+				"identifier": "@playwright/mcp",
+				"version": "0.0.73",
+				"runtimeHint": "npx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/playwright/versions/0.0.73/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/playwright/versions/0.0.73/index.html
@@ -1,0 +1,31 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/playwright",
+		"description": "Playwright MCP server for browser automation using accessibility snapshots",
+		"repository": {
+			"url": "https://github.com/microsoft/playwright-mcp",
+			"source": "github"
+		},
+		"version": "0.0.73",
+		"packages": [
+			{
+				"registryType": "npm",
+				"identifier": "@playwright/mcp",
+				"version": "0.0.73",
+				"runtimeHint": "npx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/podman/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/podman/index.html
@@ -1,0 +1,31 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/podman",
+		"description": "MCP server for container runtimes (Podman and Docker)",
+		"repository": {
+			"url": "https://github.com/manusa/podman-mcp-server",
+			"source": "github"
+		},
+		"version": "0.0.15",
+		"packages": [
+			{
+				"registryType": "npm",
+				"identifier": "podman-mcp-server",
+				"version": "0.0.15",
+				"runtimeHint": "npx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/podman/versions/0.0.15/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/podman/versions/0.0.15/index.html
@@ -1,0 +1,31 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/podman",
+		"description": "MCP server for container runtimes (Podman and Docker)",
+		"repository": {
+			"url": "https://github.com/manusa/podman-mcp-server",
+			"source": "github"
+		},
+		"version": "0.0.15",
+		"packages": [
+			{
+				"registryType": "npm",
+				"identifier": "podman-mcp-server",
+				"version": "0.0.15",
+				"runtimeHint": "npx",
+				"transport": {
+					"type": "stdio"
+				}
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-05-05T00:00:00Z",
+			"updatedAt": "2026-05-05T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/index.html
+++ b/v1.2.3/v0/servers/index.html
@@ -74,10 +74,266 @@
 					"isLatest": true
 				}
 			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/linux",
+				"description": "Tools to allow LLM clients to interact with Linux systems remotely",
+				"repository": {
+					"url": "https://github.com/rhel-lightspeed/linux-mcp-server",
+					"source": "github"
+				},
+				"version": "1.4.1",
+				"packages": [
+					{
+						"registryType": "pypi",
+						"identifier": "linux-mcp-server",
+						"version": "1.4.1",
+						"runtimeHint": "uvx",
+						"transport": {
+							"type": "stdio"
+						}
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/playwright",
+				"description": "Playwright MCP server for browser automation using accessibility snapshots",
+				"repository": {
+					"url": "https://github.com/microsoft/playwright-mcp",
+					"source": "github"
+				},
+				"version": "0.0.73",
+				"packages": [
+					{
+						"registryType": "npm",
+						"identifier": "@playwright/mcp",
+						"version": "0.0.73",
+						"runtimeHint": "npx",
+						"transport": {
+							"type": "stdio"
+						}
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/grafana",
+				"description": "MCP server for Grafana observability platform",
+				"repository": {
+					"url": "https://github.com/grafana/mcp-grafana",
+					"source": "github"
+				},
+				"version": "0.13.0",
+				"packages": [
+					{
+						"registryType": "pypi",
+						"identifier": "mcp-grafana",
+						"version": "0.13.0",
+						"runtimeHint": "uvx",
+						"transport": {
+							"type": "stdio"
+						},
+						"environmentVariables": [
+							{
+								"name": "GRAFANA_URL",
+								"description": "Grafana instance URL (e.g. http://localhost:3000)",
+								"isRequired": true,
+								"isSecret": false,
+								"format": "string"
+							},
+							{
+								"name": "GRAFANA_SERVICE_ACCOUNT_TOKEN",
+								"description": "Grafana service account token for authentication",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						]
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/atlassian",
+				"description": "Remote MCP Server connecting Jira and Confluence with LLMs and IDEs",
+				"repository": {
+					"url": "https://github.com/atlassian/atlassian-mcp-server",
+					"source": "github"
+				},
+			"version": "1.0.0",
+			"remotes": [
+				{
+					"type": "streamable-http",
+					"url": "https://mcp.atlassian.com/v1/mcp",
+					"headers": [
+						{
+							"name": "Authorization",
+							"value": "Bearer {atlassian_token}",
+							"description": "Header used for authentication",
+							"isRequired": true,
+							"isSecret": false,
+							"format": "string",
+							"variables": {
+								"atlassian_token": {
+									"description": "Atlassian API token or OAuth access token https://support.atlassian.com/atlassian-rovo-mcp-server/docs/authentication-and-authorization/",
+									"isRequired": true,
+									"isSecret": true,
+									"format": "string"
+								}
+							}
+						}
+					]
+				}
+			]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/fetch",
+				"description": "MCP server providing tools to fetch and convert web content for LLMs",
+				"repository": {
+					"url": "https://github.com/modelcontextprotocol/servers",
+					"source": "github",
+					"subfolder": "src/fetch"
+				},
+				"version": "2025.4.7",
+				"packages": [
+					{
+						"registryType": "pypi",
+						"identifier": "mcp-server-fetch",
+						"version": "2025.4.7",
+						"runtimeHint": "uvx",
+						"transport": {
+							"type": "stdio"
+						}
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/podman",
+				"description": "MCP server for container runtimes (Podman and Docker)",
+				"repository": {
+					"url": "https://github.com/manusa/podman-mcp-server",
+					"source": "github"
+				},
+				"version": "0.0.15",
+				"packages": [
+					{
+						"registryType": "npm",
+						"identifier": "podman-mcp-server",
+						"version": "0.0.15",
+						"runtimeHint": "npx",
+						"transport": {
+							"type": "stdio"
+						}
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/notion",
+				"description": "Official Notion MCP Server",
+				"repository": {
+					"url": "https://github.com/makenotion/notion-mcp-server",
+					"source": "github"
+				},
+				"version": "2.2.1",
+				"packages": [
+					{
+						"registryType": "npm",
+						"identifier": "@notionhq/notion-mcp-server",
+						"version": "2.2.1",
+						"runtimeHint": "npx",
+						"transport": {
+							"type": "stdio"
+						},
+						"environmentVariables": [
+							{
+								"name": "NOTION_API_KEY",
+								"description": "Notion integration token from https://www.notion.so/my-integrations",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						]
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-05-05T00:00:00Z",
+					"updatedAt": "2026-05-05T00:00:00Z",
+					"isLatest": true
+				}
+			}
 		}
 	],
 	"metadata": {
 		"nextCursor": "",
-		"count": 2
+		"count": 9
 	}
 }


### PR DESCRIPTION

<img width="1188" height="827" alt="Screenshot 2026-05-05 at 22 17 42" src="https://github.com/user-attachments/assets/7ce152f4-4ace-43f0-bbce-33e4486b4cf2" />

To test this you can use my deployment of this branch:
https://gastoner.github.io/mcp-registry-online/

Need to verify the token-based mcps - grafana, atlasian, notion etc..

Closes https://github.com/openkaiden/mcp-registry-online/issues/10