### PR TITLE
feat: add Xquik MCP registry entry

### DIFF
--- a/v1.2.3/v0/servers/ai.openkaiden.registry/xquik/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/xquik/index.html
@@ -1,0 +1,44 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/xquik",
+		"description": "X data platform with REST endpoints, MCP tools, extraction tools, webhooks, and write workflows.",
+		"repository": {
+			"url": "https://github.com/Xquik-dev/x-twitter-scraper",
+			"source": "github"
+		},
+		"version": "2.4.8",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://xquik.com/mcp",
+				"headers": [
+					{
+						"name": "Authorization",
+						"value": "Bearer {XQUIK_API_KEY}",
+						"description": "Xquik API key from https://dashboard.xquik.com/en/account",
+						"isRequired": true,
+						"isSecret": true,
+						"format": "string",
+						"variables": {
+							"XQUIK_API_KEY": {
+								"description": "Your Xquik API key",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-06-28T00:00:00Z",
+			"updatedAt": "2026-06-28T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/ai.openkaiden.registry/xquik/versions/2.4.8/index.html
+++ b/v1.2.3/v0/servers/ai.openkaiden.registry/xquik/versions/2.4.8/index.html
@@ -1,0 +1,44 @@
+{
+	"server": {
+		"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+		"name": "ai.openkaiden.registry/xquik",
+		"description": "X data platform with REST endpoints, MCP tools, extraction tools, webhooks, and write workflows.",
+		"repository": {
+			"url": "https://github.com/Xquik-dev/x-twitter-scraper",
+			"source": "github"
+		},
+		"version": "2.4.8",
+		"remotes": [
+			{
+				"type": "streamable-http",
+				"url": "https://xquik.com/mcp",
+				"headers": [
+					{
+						"name": "Authorization",
+						"value": "Bearer {XQUIK_API_KEY}",
+						"description": "Xquik API key from https://dashboard.xquik.com/en/account",
+						"isRequired": true,
+						"isSecret": true,
+						"format": "string",
+						"variables": {
+							"XQUIK_API_KEY": {
+								"description": "Your Xquik API key",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	"_meta": {
+		"io.modelcontextprotocol.registry/official": {
+			"status": "active",
+			"publishedAt": "2026-06-28T00:00:00Z",
+			"updatedAt": "2026-06-28T00:00:00Z",
+			"isLatest": true
+		}
+	}
+}

--- a/v1.2.3/v0/servers/index.html
+++ b/v1.2.3/v0/servers/index.html
@@ -330,10 +330,54 @@
 					"isLatest": true
 				}
 			}
+		},
+		{
+			"server": {
+				"$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+				"name": "ai.openkaiden.registry/xquik",
+				"description": "X data platform with REST endpoints, MCP tools, extraction tools, webhooks, and write workflows.",
+				"repository": {
+					"url": "https://github.com/Xquik-dev/x-twitter-scraper",
+					"source": "github"
+				},
+				"version": "2.4.8",
+				"remotes": [
+					{
+						"type": "streamable-http",
+						"url": "https://xquik.com/mcp",
+						"headers": [
+							{
+								"name": "Authorization",
+								"value": "Bearer {XQUIK_API_KEY}",
+								"description": "Xquik API key from https://dashboard.xquik.com/en/account",
+								"isRequired": true,
+								"isSecret": true,
+								"format": "string",
+								"variables": {
+									"XQUIK_API_KEY": {
+										"description": "Your Xquik API key",
+										"isRequired": true,
+										"isSecret": true,
+										"format": "string"
+									}
+								}
+							}
+						]
+					}
+				]
+			},
+			"_meta": {
+				"io.modelcontextprotocol.registry/official": {
+					"status": "active",
+					"publishedAt": "2026-06-28T00:00:00Z",
+					"updatedAt": "2026-06-28T00:00:00Z",
+					"isLatest": true
+				}
+			}
 		}
 	],
 	"metadata": {
 		"nextCursor": "",
-		"count": 9
+		"count": 10
 	}
 }


### PR DESCRIPTION
## Summary

- Add Xquik to the latest v1.2.3 static MCP registry example.
- Include the public Streamable HTTP endpoint, repository, and API key auth metadata from Xquik's public MCP server card.

## Validation

- `jq . v1.2.3/v0/servers/index.html`
- `jq . v1.2.3/v0/servers/ai.openkaiden.registry/xquik/index.html`
- `jq . v1.2.3/v0/servers/ai.openkaiden.registry/xquik/versions/2.4.8/index.html`
- Verified `.metadata.count` equals `.servers | length` and server names have no duplicates.
- `curl -fsS https://xquik.com/.well-known/mcp/server-card.json`
- `curl -fsSI https://docs.xquik.com/mcp/overview`
